### PR TITLE
コメントアウトコードの削除

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -6,7 +6,6 @@
       </p>
       <%= link_to "by #{@prototype.user.name}", user_path(@prototype.user), class: :prototype__user %>
       <% if user_signed_in? && current_user.id = @prototype.user.id %>
-      <%# if current_user = @prototype.user %>
         <div class="prototype__manage">
           <%= link_to "編集する", edit_prototype_path(@prototype), class: :prototype__btn %>
           <%= link_to "削除する", prototype_path(@prototype), method: :delete, class: :prototype__btn %>


### PR DESCRIPTION
what
コメントアウトコードの削除
why
if文がendに接続していないと判断したため