### PR TITLE
条件分岐の変更

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -27,7 +27,7 @@ class PrototypesController < ApplicationController
 
   def edit
     @user = User.new
-    @user = @prototype.user
+    @user = @prototype.user 
     unless user_signed_in?
       redirect_to root_path
     end
@@ -62,6 +62,8 @@ class PrototypesController < ApplicationController
 
   def not_log_in_hajikitai
     @prototype = Prototype.find(params[:id])
-    redirect_to root_path unless current_user == @prototype.user
+    unless current_user == @prototype.user
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -5,7 +5,7 @@
         <%= @prototype.title %>
       </p>
       <%= link_to "by #{@prototype.user.name}", user_path(@prototype.user), class: :prototype__user %>
-      <% if user_signed_in? && current_user.id = @prototype.user.id %>
+      <% if user_signed_in? %>
         <div class="prototype__manage">
           <%= link_to "編集する", edit_prototype_path(@prototype), class: :prototype__btn %>
           <%= link_to "削除する", prototype_path(@prototype), method: :delete, class: :prototype__btn %>


### PR DESCRIPTION
What
条件分岐の記述変更
　1.編集、削除ボタンをログイン時に限定(以前はuser.idとprototype.idの一致も含めていた)。
　2.before_actionにてログインユーザーとprototypeユーザーが一致した時以外はroot_pathに飛ぶよう仕様変更。
Why
　1.ひとつずつ条件を確実にクリアさせたかったため。
　2.記述をシンプルにするため。